### PR TITLE
Fix: Order Sessions according to Start Time

### DIFF
--- a/neurone_loader/loader.py
+++ b/neurone_loader/loader.py
@@ -319,7 +319,7 @@ class Recording(BaseContainer):
                         if os.path.isdir(os.path.join(self.path, dirname))
                         and 'Protocol.xml' in os.listdir(os.path.join(self.path, dirname))]
         assert len(session_dirs) > 0, "No sessions found in {}".format(self.path)
-        self.sessions = [Session(path) for path in session_dirs]
+        self.sessions = list(sorted([Session(path) for path in session_dirs], key=lambda s: s.time_start))
 
     @property
     def event_codes(self):


### PR DESCRIPTION
The recording object uses `os.listdir` to get a list of session folders. According to the python documentation `os.listdir` does not guarantee a specific order, which can create inconsistencies when relying on the order of the `Recording.sessions` list.

This orders the session list according to the starting time of the recordings, which is probably what most users will expect.